### PR TITLE
pavlenko read/favorite

### DIFF
--- a/src/favourite.html
+++ b/src/favourite.html
@@ -166,7 +166,7 @@
       <section class="favourite">
         <div class="container">
           <h1 class="visually-hidden">Favourite news</h1>
-          <div class="articles"></div>
+          <div class="articles js-articles-favourites"></div>
         </div>
       </section>
     </main>
@@ -227,6 +227,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./index.js"></script>
+    <script type="module" src="./favourite.js"></script>
   </body>
 </html>

--- a/src/favourite.js
+++ b/src/favourite.js
@@ -1,0 +1,293 @@
+const READ_KEY = "HAVE_READ"; // ключ для массива прочитанных новостей в Локальном Хранилище
+const READ_URL_KEY = "READ_URL"; // ключ для массива URL прочитанных новостей в Локальном Хранилище
+const FAVORITES_KEY = "FAVORITES";// ключ для массива новостей Фавориты в Локальном Хранилище
+
+const favouriteGallery = document.querySelector(".js-articles-favourites");
+
+favouriteGallery.addEventListener("click", onRemoveFromFavorites); // вешаем слушатель событий на галерею новостей
+
+onOpenFavorites(FAVORITES_KEY); // запуск функции для рендера страницы
+
+
+
+
+//=============== Функция при открытии страныцы "Фавориты" ==================================
+function onOpenFavorites(key) {
+    const dataFromLocaleStorage = onGetLocaleStorageData(key); // получаем данные из избранных в Локальном Хранилище
+
+    if (!dataFromLocaleStorage || dataFromLocaleStorage.length === 0) { // проверка на null или пустой массив
+        alert("Добавьте страницу заглушку пожалуйста. Файл favourite.js, 19-строка");
+        return;
+    }
+
+    onCreateMurkup(dataFromLocaleStorage);
+
+}
+
+
+//============= Функция-обработчик удаления из Фаворитов ==============================
+function onRemoveFromFavorites(event) {
+    if (!event.target.hasAttribute("data-info")) return;
+
+    const card = event.target.closest(".markup-unit");
+    
+    const cardIDLink = event.target.dataset.id; // получаем ID карточки в виде линка на первоисточник
+
+    const dataFromLocaleStorage = onGetLocaleStorageData(FAVORITES_KEY); // получаем массив из Локального хранилища
+
+    if (!dataFromLocaleStorage) { // проверка на null из пустого Локального Хранилища 
+        console.log("News isn't in favorites");
+        return;
+    };
+
+    const index = dataFromLocaleStorage.find((card, index) => { // получаем индекс нужной карточки
+        if (card.link === cardIDLink) {
+            return index;
+        }
+    });
+
+    dataFromLocaleStorage.splice(index, 1) // удаляем карточку по индексу
+
+    if (dataFromLocaleStorage.length === 0) { // проверяем пустой массив или нет
+        localStorage.removeItem('FAVORITES');
+        onRemoveElement(card);
+        return;
+    }
+
+    onSetLocaleStorageData(FAVORITES_KEY, dataFromLocaleStorage); // сетаем в локальное хранилище модифицированный массив
+
+    onRemoveElement(card);        
+}
+
+
+
+//============= Функция для рендера страницы ===========================================
+function onCreateMurkup(arrayOfObjects) { 
+
+    const favoritesMurkup = arrayOfObjects.map(newsObject => { // перебираем массив из Локального хранилища и создаем разметку для карточки
+        const { title, category, date, link, description, imageURL } = newsObject;
+        const favorite = JSON.stringify(newsObject);
+
+        //Логика отображения прочитанных на странице Фавориты--------------------------------------
+        let check = "display: none;";// стиль по умолчанию для плашки "Already read"
+        const urlFromLocaleStorage = onGetLocaleStorageData(READ_URL_KEY); // получаем массив URL прочитанных новостей
+        check = checkIfReadByUrl(urlFromLocaleStorage, link); //возвращает строку с разным свойством display
+        if (!check) { // проверка на undefined
+            check = "display: none;"
+        }
+        //---------------------------------------------------------------------
+        
+        return `<li class="markup-unit markup-unit__read" name="card">
+    <p class="markup-unit__section">${category}</p>
+    <p class="markup-unit__already-read" style='${check}'>Already read
+    <svg class="markup-unit__icon-check" width="18" height="18" viewBox="0 0 37 32">
+      <path stroke="#00DD73" stroke-linejoin="miter" stroke-linecap="square" stroke-miterlimit="4" stroke-width="2.2857" d="M28.779 6.389c-0.288 0.009-0.546 0.131-0.732 0.323l-16.313 16.313-6.713-6.713c-0.195-0.209-0.473-0.339-0.78-0.339-0.589 0-1.067 0.478-1.067 1.067 0 0.308 0.13 0.585 0.339 0.78l0.001 0.001 7.467 7.467c0.193 0.193 0.459 0.312 0.754 0.312s0.561-0.119 0.754-0.312v0l17.067-17.067c0.199-0.194 0.323-0.465 0.323-0.765 0-0.589-0.478-1.067-1.067-1.067-0.011 0-0.022 0-0.033 0l0.002-0z"></path>
+    </svg>
+    </p>
+    <img 
+        class="markup-unit__card-image" 
+        src="${imageURL}" 
+        alt="placeholder"
+        />
+    <button 
+        class="markup-unit__add-favorite js-fbutton js-favorites" 
+        type="button" 
+        data-info
+        data-favorite='${favorite}'
+        data-id='${link}'
+      >
+      <p 
+        class="markup-unit__favorite-text js-fbutton"
+        data-favorite='${favorite}'
+        style="pointer-events: none;"
+      >
+          Remove from favourites
+      </p>
+      <svg 
+          data-favorite='${favorite}'  
+          class="markup-unit__favorite-icon markup-unit__favorite-icon--active js-fbutton" 
+          width="15" 
+          height="15" 
+          viewBox="0 0 37 32"
+          style="pointer-events: none;"
+        >
+        <path style="stroke: var(--color1, #4440f7)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.2857" d="M10.666 2.286c-4.207 0-7.619 3.377-7.619 7.543 0 3.363 1.333 11.345 14.458 19.413 0.235 0.143 0.505 0.219 0.78 0.219s0.545-0.076 0.78-0.219c13.125-8.069 14.458-16.050 14.458-19.413 0-4.166-3.412-7.543-7.619-7.543s-7.619 4.571-7.619 4.571-3.412-4.571-7.619-4.571z"></path>
+      </svg>
+    </button>
+    <h2 class="markup-unit__card-header" name="card_header">
+        ${title}
+    </h2>
+    <p class="markup-unit__card-text" name="card_text">
+        ${description}
+    </p>
+    <div class="markup-unit__card-footer">
+        <p class="markup-unit__card-date">${date}</p>
+      <a 
+        class="markup-unit__read-more" 
+        href="${link}" 
+        name="read_more"
+        data-favorite='${favorite}'
+      >
+          Read more
+      </a>
+    </div>
+    </li>`;
+    }).join(" ");
+
+    return favouriteGallery.innerHTML = favoritesMurkup;
+}
+
+
+//============= Функция удаления элементов из ДОМ ======================================
+function onRemoveElement(element) {
+    element.remove();
+}
+
+
+// Логика работы с "Прочитанными" на странице Фавориты --------------------------------------------------------------------
+
+favouriteGallery.addEventListener('click', onReadMoreClick); // вешаем слушатель событий на контейнер с новостями
+
+
+
+//============== Функция обработчик по клику на ссылку ReadMore ==============================================
+function onReadMoreClick(event) {
+    event.preventDefault();
+    if (!event.target.classList.contains("markup-unit__read-more")) return; // проверяем туда ли тырнули
+    
+    const clickDate = receiveDate(); // получаем дату клика в виде 20/02/2023    
+    const parsedCardData = makeParseJson(event.target.dataset.favorite); // получаем объект данных с карточки которая находится на странице
+    const urlFromLocaleStorage = onGetLocaleStorageData(READ_URL_KEY); // получаем из локального хранилища массив URL прочитанных новстей
+    const dataFromLocaleStorage = onGetLocaleStorageData(READ_KEY); // получаем массив объектов прочитанных новостей из Локального Хранилища
+
+
+//------ Логика для массива ссылок прочитаных новостей
+    addHaveReadLink(urlFromLocaleStorage, parsedCardData.link, READ_URL_KEY)
+
+//------ Логика для массива объектов с датой и новостями    
+    addHaveReadNews(dataFromLocaleStorage, parsedCardData, clickDate, READ_KEY);
+}
+
+//========== Функция получения даты в формате 20/02/2021
+function receiveDate() {
+    const date = new Date();
+    const day = addLeadingZero(date.getDate());
+    const month = addLeadingZero(date.getMonth() + 1);
+    const year = addLeadingZero(date.getFullYear());
+    return `${day}/${month}/${year}`;
+}
+function addLeadingZero(value) {
+    return String(value).padStart(2, '0');
+}
+
+//========== Функция добавления ссылок на новости в отдельный массив в Locale Storage ============
+function addHaveReadLink(array, link, key) {
+    if (array) { // если вернулся массив ссылок
+        const urlPresenceResult = array.some(item => item === link); // ищем есть ли совпадение с link результат
+
+        if (!urlPresenceResult) { // если нету такого URL в массиве прочитанных новостей            
+            array.push(link); //добавляем в массив URL из локального хранилища URL текущей новости
+            onSetLocaleStorageData(key, array); // сетаем в хранилище обновленный массив URL прочитанных новостей
+        }
+
+        return;
+    }  
+
+    onSetLocaleStorageData(key, [link]); // если массива нет, создаем массив и помещаем туда url прочитанной новости и сетаем в Хранилище
+}
+
+//========== Функция добавления объекта прочитанных новостей согласно дате просмотра =============
+function addHaveReadNews(newsArr, cardObj, date, key) {
+    if (newsArr) { // если возвращается массив дат с новостями из Локального Хранилища
+        
+        const resultsArr = [];        
+
+        newsArr.forEach(object => {// перебираем все объекты прочитанных новостей с датами из Локального Хранилища
+            const { newsArray } = object;
+            
+            const isPresent = newsArray.some(news => news.link === cardObj.link);// проверяем есть ли новость в коллекции
+            resultsArr.push(isPresent);
+        });
+        
+        const isNewsPresent = resultsArr.some(result => result); // проверка присутствия новости
+
+        if (!isNewsPresent) { // Если новость не присутствует в прочитанных
+            const datePresence = newsArr.some(item => item.whenRead === date); // проверяем есть ли сегодняшняя дата в массиве прочитанных
+            
+            if (datePresence) { // если дата уже присутствует в массиве
+                const arrWithNewObject = newsArr.map(item => { // создаем новый массив перебирая массив из Локального Хранилища
+                    const { whenRead, newsArray } = item;
+                    if (whenRead === date) { //когда совпадение по дате
+                        newsArray.push(cardObj); // пушим в массив новостей объект с карточки
+                        return { whenRead, newsArray };
+                    }
+                });
+                console.log(arrWithNewObject);
+                onSetLocaleStorageData(key, arrWithNewObject);  // сетаем модифицированный массив в локальное хранилище
+                return;
+            }
+
+            const whenHaveReadObject = {  // создаем новый объект с датой когда новость прочитана и массивом прочитанных на эту дату
+                whenRead: date,
+                newsArray: [cardObj]
+            };
+
+            newsArr.push(whenHaveReadObject);// пушим объект с новостью и датой в существующий массив из Локального Хранилища
+
+            onSetLocaleStorageData(key, newsArr); // сетаем новый массив в локальное хранилище
+        }
+
+        return;
+    }
+
+    const haveReadArray = []; // создаем массив который будем сетать в Локальное хранилище
+    const whenHaveReadObject = {  // создаем новый объект с датой когда новость прочитана и массивом прочитанных на эту дату
+        whenRead: date,
+        newsArray: [cardObj]
+    };
+
+    haveReadArray.push(whenHaveReadObject); // пушим в новый массив объект с датой и массивом прочитанных новостей
+
+    onSetLocaleStorageData(key, haveReadArray); // сетаем массив с прочитанными новостями и датой в Локальное Хранилище
+}
+//-----------------------------------------------------------------------------------------------------------------------------------
+
+
+
+//==================== Сервис Функции ===========================================
+function onGetLocaleStorageData(key) {
+    try {
+        return JSON.parse(localStorage.getItem(key)); // получаем массив объектов из Локального Хранилища
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+function makeParseJson(stringData) {
+    try {
+        return JSON.parse(stringData);
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+function onSetLocaleStorageData(key, data) {
+    try {
+        localStorage.setItem(key, JSON.stringify(data));
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+function checkIfReadByUrl(array, newsLink) {
+    if (!array || array.length === 0) { // проверка на null или пустой массив
+        return;
+    }
+    const compareResult = array.some(item => item === newsLink);
+    if (compareResult) {
+        return "display: flex;";
+    } else {
+        return "display: none;"; 
+    }
+     
+}

--- a/src/images/accordion-arrow.svg
+++ b/src/images/accordion-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="9" viewBox="0 0 15 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.7625 9L-3.18545e-07 7.28745L7.5 3.27835e-07L15 7.28745L13.2375 9L7.5 3.43725L1.7625 9Z" fill="#111321"/>
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -174,7 +174,7 @@
             </div>
           </div>
           <!-- <div class="weather" name="weather"></div> -->
-          <ul class="articles articles-background" name="articles"></ul>
+          <ul class="articles articles-background js-articles" name="articles"></ul>
           <!-- <div class="pagination" name="pagination"></div> -->
         </div>
       </section>

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import './js/calendar/index';
 import './js/pagination.js';
 import './js/homepage-render';
 import './js/fetch_weather';
+import './js/home-favourites-read';
 
 import { formEl } from './js/homepage-render';
 import { onInputSubmit } from './js/homepage-render';

--- a/src/js/home-favourites-read.js
+++ b/src/js/home-favourites-read.js
@@ -1,0 +1,211 @@
+//================================ Логика страницы Index, действие с Прочитанными =====================================================
+const newsGallery = document.querySelector(".js-articles");
+
+const READ_KEY = "HAVE_READ"; // ключ для массива прочитанных новостей в Локальном Хранилище
+const READ_URL_KEY = "READ_URL"; // ключ для массива URL прочитанных новостей в Локальном Хранилище
+
+newsGallery.addEventListener('click', onReadMoreClick);
+
+
+
+//============== Функция обработчик по клику на ссылку ReadMore ==============================================
+function onReadMoreClick(event) {
+    event.preventDefault();
+    if (!event.target.classList.contains("markup-unit__read-more")) return; // проверяем туда ли тырнули
+    
+    const clickDate = receiveDate(); // получаем дату клика в виде 20/02/2023    
+    const parsedCardData = makeParseJson(event.target.dataset.favorite); // получаем объект данных с карточки которая находится на странице
+    const urlFromLocaleStorage = onGetLocaleStorageData(READ_URL_KEY); // получаем из локального хранилища массив URL прочитанных новстей
+    const dataFromLocaleStorage = onGetLocaleStorageData(READ_KEY); // получаем массив объектов прочитанных новостей из Локального Хранилища
+
+
+//------ Логика для массива ссылок прочитаных новостей
+    addHaveReadLink(urlFromLocaleStorage, parsedCardData.link, READ_URL_KEY)
+
+//------ Логика для массива объектов с датой и новостями    
+    addHaveReadNews(dataFromLocaleStorage, parsedCardData, clickDate, READ_KEY);
+}
+
+
+
+
+//================================= Логика страницы Index, действие с Фавориты ============================================================
+
+const FAVORITES_KEY = "FAVORITES";
+let favorites = [];
+
+newsGallery.addEventListener('click', onAddRemoveLocaleStorageData); // вешаем слушателя событий на контейнер с новостями
+
+
+//=========== Функция-обработчик Клика на кнопку добавить/убрать в/из Фавориты ==============================================
+function onAddRemoveLocaleStorageData(event) {    
+    if (!event.target.hasAttribute("data-info")) return;// проверка туда ли тырнули
+    
+    const parsedCardData = makeParseJson(event.target.dataset.favorite); // получаем объект данных с карточки которая находится на странице
+    const dataFromLocaleStorage = onGetLocaleStorageData(FAVORITES_KEY); // получаем массив объектов из Локального Хранилища
+
+    if (event.target.classList.contains("js-favorites")) {// проверка условия содержит ли кнопка класс-метку что новость уже добавлена в избранное
+
+        event.target.textContent = "Add to favorites"; // изменение текстового контента кнопки
+
+        event.target.classList.remove("js-favorites"); // убираем класс-метку что карточка добавлена в избранное
+
+        if (!dataFromLocaleStorage) { // проверка на null из пустого Локального Хранилища 
+            console.log("News isn't in favorites");
+            return;
+        };
+
+        const index = dataFromLocaleStorage.find((card, index) => { // получаем индекс нужной карточки
+            if (card.link === parsedCardData.link) {
+                return index;
+            }
+        });
+
+        dataFromLocaleStorage.splice(index, 1) // удаляем карточку по индексу
+
+        if (dataFromLocaleStorage.length === 0) { // проверяем пустой массив или нет
+            localStorage.removeItem('FAVORITES');
+            return;
+        }
+
+        onSetLocaleStorageData(FAVORITES_KEY, dataFromLocaleStorage); // сетаем в локальное хранилище модифицированный массив
+
+        return;        
+    }
+    //В противном случае==========//
+    event.target.textContent = "Remove from favorites"; // изменение текстового контента кнопки
+
+    event.target.classList.add("js-favorites"); // добавляем класс-метку что карточка добавлена в избранное
+
+    if (dataFromLocaleStorage) { // проверка на возврат null из пустого массива
+        const findPresenceResult = dataFromLocaleStorage.some(card => card.link === parsedCardData.link); // получаем булевое значение есть ли новость в избранном
+
+        if (findPresenceResult) { // делаем условие новости на присутствие в Локальном Хранилище в избранном
+            console.log("It's allredy in Favorites");
+            return;
+        }
+
+        favorites = [...dataFromLocaleStorage]; // распыляем в массив "Фавориты" данные из массива полученные из Локального хранилища
+    }
+
+    favorites.push(parsedCardData); // добавляем объект с данными карточки новости в массив "Фавориты"
+
+    onSetLocaleStorageData(FAVORITES_KEY, favorites); // сетаем в локальное хранилище
+
+    favorites = []; // очищаем массив "Фавориты"
+}
+
+
+//========== Функция для Получения Данных из Locale Storage =======================================
+function onGetLocaleStorageData(key) {
+    try {
+        return JSON.parse(localStorage.getItem(key)); // получаем массив объектов из Локального Хранилища
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+
+//========== Функция парсинга данных из JSON файла =================================================
+function makeParseJson(stringData) {
+    try {
+        return JSON.parse(stringData);
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+
+//========== Функкция Добавления Данных в Locale Storage ========================================
+function onSetLocaleStorageData(key, data) {
+    try {
+        localStorage.setItem(key, JSON.stringify(data));
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+
+//========== Функция получения даты в формате 20/02/2021
+function receiveDate() {
+    const date = new Date();
+    const day = addLeadingZero(date.getDate());
+    const month = addLeadingZero(date.getMonth() + 1);
+    const year = addLeadingZero(date.getFullYear());
+    return `${day}/${month}/${year}`;
+}
+function addLeadingZero(value) {
+    return String(value).padStart(2, '0');
+}
+
+//========== Функция добавления ссылок на новости в отдельный массив в Locale Storage ============
+function addHaveReadLink(array, link, key) {
+    if (array) { // если вернулся массив ссылок
+        const urlPresenceResult = array.some(item => item === link); // ищем есть ли совпадение с link результат
+
+        if (!urlPresenceResult) { // если нету такого URL в массиве прочитанных новостей            
+            array.push(link); //добавляем в массив URL из локального хранилища URL текущей новости
+            onSetLocaleStorageData(key, array); // сетаем в хранилище обновленный массив URL прочитанных новостей
+        }
+
+        return;
+    }  
+
+    onSetLocaleStorageData(key, [link]); // если массива нет, создаем массив и помещаем туда url прочитанной новости и сетаем в Хранилище
+}
+
+//========== Функция добавления объекта прочитанных новостей согласно дате просмотра =============
+function addHaveReadNews(newsArr, cardObj, date, key) {
+    if (newsArr) { // если возвращается массив дат с новостями из Локального Хранилища
+        
+        let resultsArr = []; // Массив-прокладка       
+
+        newsArr.forEach(object => {// перебираем все двухуровневые объекты прочитанных новостей с датами из Локального Хранилища
+            const { newsArray } = object;
+            
+            const isPresent = newsArray.some(news => news.link === cardObj.link);// проверяем есть ли новость в коллекции
+            resultsArr.push(isPresent);
+        });
+        
+        const isNewsPresent = resultsArr.some(result => result); // проверка присутствия новости, если присутствует то выходим
+        resultsArr = []; // очищаем массив-прокладку на всякий случай
+
+        if (!isNewsPresent) { // Если новость не присутствует в прочитанных
+            const datePresence = newsArr.some(item => item.whenRead === date); // проверяем есть ли сегодняшняя дата в массиве прочитанных
+            
+            if (datePresence) { // если дата уже присутствует в массиве
+                const arrWithNewObject = newsArr.map(item => { // создаем новый массив перебирая массив из Локального Хранилища
+                    const { whenRead, newsArray } = item;
+                    if (whenRead === date) { //когда совпадение по дате
+                        newsArray.push(cardObj); // пушим в массив новостей объект с карточки
+                        return { whenRead, newsArray };
+                    }
+                });
+                
+                onSetLocaleStorageData(key, arrWithNewObject);  // сетаем модифицированный массив в локальное хранилище
+                return;
+            }
+
+            const whenHaveReadObject = {  // создаем новый объект с датой когда новость прочитана и массивом для Прочитанных на эту дату
+                whenRead: date,
+                newsArray: [cardObj]
+            };
+
+            newsArr.push(whenHaveReadObject);// пушим объект с новостью и датой в существующий массив из Локального Хранилища
+
+            onSetLocaleStorageData(key, newsArr); // сетаем новый массив в локальное хранилище
+        }
+
+        return;
+    }
+    // Если не возвращается массив
+    const haveReadArray = []; // создаем массив который будем сетать в Локальное хранилище
+    const whenHaveReadObject = {  // создаем новый объект с датой когда новость прочитана и массивом прочитанных на эту дату
+        whenRead: date,
+        newsArray: [cardObj]
+    };
+
+    haveReadArray.push(whenHaveReadObject); // пушим в новый массив объект с датой и массивом прочитанных новостей
+
+    onSetLocaleStorageData(key, haveReadArray); // сетаем массив с прочитанными новостями и датой в Локальное Хранилище
+}

--- a/src/js/markup.js
+++ b/src/js/markup.js
@@ -165,14 +165,16 @@ export class TemplateCards {
         alt="placeholder"
         />
     <button 
-        class="markup-unit__add-favorite" 
+        class="markup-unit__add-favorite js-fbutton" 
         type="button" 
         data-info
         data-favorite='${favorite}'
+        data-id='${unload.path}'
       >
       <p 
         class="markup-unit__favorite-text js-fbutton"
         data-favorite='${favorite}'
+        style="pointer-events: none;"
       >
           Add to favorite
       </p>
@@ -182,6 +184,7 @@ export class TemplateCards {
           width="15" 
           height="15" 
           viewBox="0 0 37 32"
+          style="pointer-events: none;"
         >
         <path style="stroke: var(--color1, #4440f7)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.2857" d="M10.666 2.286c-4.207 0-7.619 3.377-7.619 7.543 0 3.363 1.333 11.345 14.458 19.413 0.235 0.143 0.505 0.219 0.78 0.219s0.545-0.076 0.78-0.219c13.125-8.069 14.458-16.050 14.458-19.413 0-4.166-3.412-7.543-7.619-7.543s-7.619 4.571-7.619 4.571-3.412-4.571-7.619-4.571z"></path>
       </svg>
@@ -196,15 +199,15 @@ export class TemplateCards {
         <p class="markup-unit__card-date">${unload.date}</p>
       <a 
         class="markup-unit__read-more" 
-        href="${unload.path} 
+        href="${unload.path}" 
         name="read_more"
+        data-favorite='${favorite}'
       >
           Read more
       </a>
     </div>
     </li>`;
-        })
-        .join('');
+    }).join('');
       return bodyArticles.insertAdjacentHTML('beforeend', valueReceiver);
     } catch (error) {
       console.log(error);

--- a/src/read.html
+++ b/src/read.html
@@ -40,16 +40,17 @@
               <a href="./index.html" class="menu__link">Home</a>
             </li>
             <li class="menu__item">
-              <a href="./favourite.html" class="menu__link menu__link"
-                >Favorite</a
-              >
+              <a href="./favourite.html" class="menu__link menu__link">
+                Favorite
+              </a>
             </li>
             <li class="menu__item">
               <a
                 href="./read.html"
                 class="menu__link menu__link menu__link--current"
-                >Read</a
               >
+                Read
+              </a>
             </li>
           </ul>
         </nav>
@@ -168,7 +169,13 @@
       <section class="read">
         <div class="container">
           <h1 class="visually-hidden">Read news</h1>
-          <div class="articles"></div>
+          <div class="articles js-haveread">
+            <div class="accordion" id="accordion">
+              <ul class="accordion-list">
+
+              </ul>
+            </div>
+          </div>
         </div>
       </section>
     </main>
@@ -228,6 +235,6 @@
         </p>
       </div>
     </footer>
-    <script type="module" src="./index.js"></script>
+    <script type="module" src="./read.js"></script>
   </body>
 </html>

--- a/src/read.js
+++ b/src/read.js
@@ -1,0 +1,226 @@
+const READ_KEY = "HAVE_READ"; // ключ для массива прочитанных новостей в Локальном Хранилище
+const READ_URL_KEY = "READ_URL"; // ключ для массива URL прочитанных новостей в Локальном Хранилище
+const FAVORITES_KEY = "FAVORITES";
+let favorites = [];
+
+const accordionRef = document.querySelector(".js-haveread"); // получаем ссылку на секцию аккордиона
+const accordionListRef = document.querySelector(".accordion-list"); // получаем ссылку на панель с новостями
+
+accordionListRef.addEventListener("click", onFavoriteClick); // делегируем слушание на секцию аккордиона
+
+onOpenFavorites(READ_KEY);
+
+
+//====== Функция-обработчик нажатия на кнопку Фавориты ==================
+function onFavoriteClick(event) {
+    if (!event.target.hasAttribute("data-info")) return;// проверка туда ли тырнули
+    
+    const parsedCardData = makeParseJson(event.target.dataset.favorite); // получаем объект данных с карточки которая находится на странице
+    const dataFromLocaleStorage = onGetLocaleStorageData(FAVORITES_KEY); // получаем массив объектов из Локального Хранилища
+
+    if (event.target.classList.contains("js-favorites")) {// проверка условия содержит ли кнопка класс-метку что новость уже добавлена в избранное
+
+        event.target.textContent = "Add to favorites"; // изменение текстового контента кнопки
+
+        event.target.classList.remove("js-favorites"); // убираем класс-метку что карточка добавлена в избранное
+
+        if (!dataFromLocaleStorage) { // проверка на null из пустого Локального Хранилища 
+            console.log("News isn't in favorites");
+            return;
+        };
+
+        const index = dataFromLocaleStorage.find((card, index) => { // получаем индекс нужной карточки
+            if (card.link === parsedCardData.link) {
+                return index;
+            }
+        });
+
+        dataFromLocaleStorage.splice(index, 1) // удаляем карточку по индексу
+
+        if (dataFromLocaleStorage.length === 0) { // проверяем пустой массив или нет
+            localStorage.removeItem('FAVORITES');
+            return;
+        }
+
+        onSetLocaleStorageData(FAVORITES_KEY, dataFromLocaleStorage); // сетаем в локальное хранилище модифицированный массив
+
+        return;        
+    }
+    //В противном случае==========//
+    event.target.textContent = "Remove from favorites"; // изменение текстового контента кнопки
+
+    event.target.classList.add("js-favorites"); // добавляем класс-метку что карточка добавлена в избранное
+
+    if (dataFromLocaleStorage) { // проверка на возврат null из пустого массива
+        const findPresenceResult = dataFromLocaleStorage.some(card => card.link === parsedCardData.link); // получаем булевое значение есть ли новость в избранном
+
+        if (findPresenceResult) { // делаем условие новости на присутствие в Локальном Хранилище в избранном
+            console.log("It's allredy in Favorites");
+            return;
+        }
+
+        favorites = [...dataFromLocaleStorage]; // распыляем в массив "Фавориты" данные из массива полученные из Локального хранилища
+    }
+
+    favorites.push(parsedCardData); // добавляем объект с данными карточки новости в массив "Фавориты"
+
+    onSetLocaleStorageData(FAVORITES_KEY, favorites); // сетаем в локальное хранилище
+
+    favorites = []; // очищаем массив "Фавориты"
+
+}
+
+//=============== Функция при открытии страныцы "Прочитанные" ==================================
+function onOpenFavorites(key) {
+    const dataFromLocaleStorage = onGetLocaleStorageData(key); // получаем данные из избранных в Локальном Хранилище
+    
+    if (!dataFromLocaleStorage || dataFromLocaleStorage.length === 0) { // проверка на null или пустой массив
+        alert("Добавьте страницу заглушку пожалуйста. Файл read.js, 78-строка");
+        return;
+    }
+
+    onCreateReadMurkup(dataFromLocaleStorage);
+}
+
+//============== Функция рендера разметки ======================================
+function onCreateReadMurkup(array) {
+    array.forEach(date => { // перебираем массив с объектами со свойством даты и массивом новостей
+        
+        const firstMurkup = createFirstMurkup(date); // создаем разметку секции аккордеона с датой для новостей (разметка первого уровня)
+        accordionListRef.insertAdjacentHTML("beforeend", firstMurkup); // рендерим эту разметку 
+
+        
+        const accordionPanel = document.querySelector(".accordion-list_panel"); // получаем ссылку на новосозданный элемент
+        
+
+        accordionPanel.innerHTML = date.newsArray.map(newsObject => {// рендерим разметку непосредственно новостей (разметка второго внутреннего уровня)
+            const { title, category, date, link, description, imageURL } = newsObject;
+            const favorite = JSON.stringify(newsObject);
+
+            //Логика проверки наличия новости в Фаворитах ------------------------------------------
+            const fromFavorites = onGetLocaleStorageData(FAVORITES_KEY); // получаем массив из фаворитов из Локального Хранилища
+            let configReadMarkup = checkFavouritesByUrl(fromFavorites, link) //по результату проверки возвращается объект настроек который используется для добавления динамических свойств в разметку
+            if (!configReadMarkup) {// на случай undefined
+                configReadMarkup = {
+                    class: "zaglushka",
+                    addRemove: "Add to favourites"
+                }
+            }
+            //--------------------------------------------------------------------------------------
+            return `<li class="markup-unit markup-unit__read" name="card">
+    <p class="markup-unit__section">${category}</p>
+    
+    <img 
+        class="markup-unit__card-image" 
+        src="${imageURL}" 
+        alt="placeholder"
+        />
+    <button 
+        class="markup-unit__add-favorite js-fbutton ${configReadMarkup.class}" 
+        type="button" 
+        data-info
+        data-favorite='${favorite}'
+        data-id='${link}'
+      >
+      <p 
+        class="markup-unit__favorite-text js-fbutton"
+        data-favorite='${favorite}'
+        style="pointer-events: none;"
+      >
+          ${configReadMarkup.addRemove}
+      </p>
+      <svg 
+          data-favorite='${favorite}'  
+          class="markup-unit__favorite-icon markup-unit__favorite-icon--active js-fbutton" 
+          width="15" 
+          height="15" 
+          viewBox="0 0 37 32"
+          style="pointer-events: none;"
+        >
+        <path style="stroke: var(--color1, #4440f7)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.2857" d="M10.666 2.286c-4.207 0-7.619 3.377-7.619 7.543 0 3.363 1.333 11.345 14.458 19.413 0.235 0.143 0.505 0.219 0.78 0.219s0.545-0.076 0.78-0.219c13.125-8.069 14.458-16.050 14.458-19.413 0-4.166-3.412-7.543-7.619-7.543s-7.619 4.571-7.619 4.571-3.412-4.571-7.619-4.571z"></path>
+      </svg>
+    </button>
+    <h2 class="markup-unit__card-header" name="card_header">
+        ${title}
+    </h2>
+    <p class="markup-unit__card-text" name="card_text">
+        ${description}
+    </p>
+    <div class="markup-unit__card-footer">
+        <p class="markup-unit__card-date">${date}</p>
+      <a 
+        class="markup-unit__read-more" 
+        href="${link}" 
+        name="read_more"
+        data-favorite='${favorite}'
+      >
+          Read more
+      </a>
+    </div>
+    </li>`; 
+        }).join(" ");
+
+    });
+}
+
+function createFirstMurkup(obj) {
+    return `<li class="accordion-list_item">
+                <div class="accordion-title_wrapper">
+                    <p class="accordion-list_title">
+                        ${obj.whenRead}
+                    </p>
+                    <div class="accordion-arrow__wraper">
+                        <svg width="15" height="9" viewBox="0 0 15 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M1.7625 9L-3.18545e-07 7.28745L7.5 3.27835e-07L15 7.28745L13.2375 9L7.5 3.43725L1.7625 9Z" fill="#111321"/>
+                        </svg>
+                    </div>
+                </div>
+                <div class="accordion-list_panel"></div>
+            </li>`;
+}
+
+function onGetLocaleStorageData(key) {
+    try {
+        return JSON.parse(localStorage.getItem(key)); // получаем массив объектов из Локального Хранилища
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+//========== Функция парсинга данных из JSON файла =================================================
+function makeParseJson(stringData) {
+    try {
+        return JSON.parse(stringData);
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+
+//========== Функкция Добавления Данных в Locale Storage ========================================
+function onSetLocaleStorageData(key, data) {
+    try {
+        localStorage.setItem(key, JSON.stringify(data));
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+function checkFavouritesByUrl(array, newsLink) {
+    if (!array || array.length === 0) { // проверка на null или пустой массив
+        return;
+    }
+    const compareResult = array.some(item => item.link === newsLink);
+    if (compareResult) {
+        return {
+            class: "js-favorites",
+            addRemove: "Remove from favorites"
+        };
+    } else {
+        return {
+            class: "zaglushka",
+            addRemove: "Add to favourites"
+        };
+    }
+     
+}


### PR DESCRIPTION
Описание нюансов.
1. Сейчас при нажатии на ссылки Read More ничего не будет происходить. На обработчики поставлен prevent.Default() чтобы не происходило перехода, это для того что бы они (переходы) не мешали отслеживанию работы с Локальным Хранилищем. Решение - закомментировать или удалить: строка 13 в файле home-favourite-read.js, строка 155 в файле favourite.js
2. Когда будешь тестировать зайди на страницы Favourites и Read когда они пустые, перед этим ничего не добавляй или почисти локальное хранилище. Там выскочит alert с просьбой поставить страницы заглушки и адреса конкретно куда.
3. На кнопках Add to favourites на всех внутренних элементах стоит инлайн стиль pointer-event: none; не снимай пожалуйста иначе накроется вся логика. Стилизацию делаем только через кнопку. То есть динамика (ховер, фокус) на внутренних элементах не будет работать, но на кнопке, как родительском элементе будет работать все.
4. В файле home-favourite-read.js посмотри пожалуйста функцию onReadMoreClick(event). Это основная логика по добавлению новостей и даты просмотра в Локальное хранилище. А именно функцию addHaveReadNews(); это она ответственна за создание двухуровневого объекта с датой публикации и массивом новостей. По сути она работает идеально для одной даты, а на второй дате она спотыкается на добавлении второй новости. Все остальное в onReadMoreClick(event) работает прекрасно и без ошибок. Так же я не делал экспорт, импорт по файлам поэтому там есть дублирование между favourite.js read,js и home-favourite-read.js. По крайней мере все отлажено работает.
5.  Логика кросс проверок находится в функциях которые делают разметку onCreateMurkup строка 65 файла favourite.js и 
onCreateReadMurkup строка 100 файла read,js. Если правильно внедрить эти две логики для главной страницы то будет подсвечивать сразу при рендере, какая прочитана и какая в Фаворитах.